### PR TITLE
Use configured CP guard for user management

### DIFF
--- a/src/Auth/UserRepositoryManager.php
+++ b/src/Auth/UserRepositoryManager.php
@@ -30,7 +30,9 @@ class UserRepositoryManager extends Manager
 
     public function createEloquentDriver(array $config)
     {
-        $config['model'] = $this->app['config']['auth.providers.users.model'];
+        $guard = $this->app['config']['statamic.users.guards.cp'];
+        $provider = $this->app['config']["auth.guards.$guard.provider"];
+        $config['model'] = $this->app['config']["auth.providers.$provider.model"];
 
         return new EloquentRepository($config);
     }


### PR DESCRIPTION
The guard provider is now hardcoded to users.
This way it uses the provider of the guard configured in `statamic.users.guards.cp`

This fixes a potential mismatch between the user table used for logging into the CP and the user table used on `cp/users`